### PR TITLE
Add ability to add source to charts

### DIFF
--- a/hurumap/static/js/charts.js
+++ b/hurumap/static/js/charts.js
@@ -26,6 +26,7 @@ function Chart(options) {
         chart.chartDataKey = options.chartDataKey;
         chart.chartChartTitle = options.chartChartTitle || null;
         chart.chartQualifier = options.chartQualifier || null;
+        chart.chartSource = options.chartSource || null;
         chart.chartInitialSort = options.chartInitialSort || null;
         chart.chartStatType = options.chartStatType || 'number';
         chart.chartNullLabel = options.chartNullLabel || "N/A";
@@ -288,6 +289,9 @@ function Chart(options) {
         if (!!chart.chartQualifier) {
             chart.addChartQualifier(chart.chartContainer);
         }
+        if (!!chart.chartSource) {
+            chart.addChartSource(chart.chartContainer);
+        }
         chart.addActionLinks();
 
         return chart;
@@ -516,6 +520,9 @@ function Chart(options) {
         if (!!chart.chartQualifier) {
             chart.addChartQualifier(chart.chartContainer);
         }
+        if (!!chart.chartSource) {
+            chart.addChartSource(chart.chartContainer);
+        }
         chart.addActionLinks();
 
         return chart;
@@ -723,6 +730,9 @@ function Chart(options) {
         if (!!chart.chartQualifier) {
             chart.addChartQualifier(chart.chartContainer);
         }
+        if (!!chart.chartSource) {
+            chart.addChartSource(chart.chartContainer);
+        }
         chart.addActionLinks();
 
         return chart;
@@ -805,6 +815,7 @@ function Chart(options) {
                 chartType: chart.chartType,
                 chartHeight: 200,
                 chartQualifier: (chart.chartQualifier || ''),
+                chartSource: (chart.chartSource || ''),
                 chartTitle: (chart.chartChartTitle || ''),
                 initialSort: (chart.chartInitialSort || ''),
                 statType: (chart.chartStatType || '')
@@ -1156,6 +1167,28 @@ function Chart(options) {
         }
     }
 
+    chart.addChartSource = function(container) {
+        if (!!chart.chartSource) {
+            var link = chart.chartSource
+            var title = chart.chartSource
+            if (typeof chart.chartSource == 'object') {
+                link = chart.chartSource.link
+                title = chart.chartSource.title || link
+            }
+            if (link) {
+                container.append("span")
+                    .classed("chart-qualifier", true)
+                    .append("a")
+                    .attr("href", link)
+                    .text("Source: " + title);
+
+                chart.updateSettings({
+                    height: parseInt(chart.settings.height) + 20
+                });
+            }
+        }
+    }
+
     // format percentages and/or dollar signs
     chart.valFmt = function(value, decimals) {
         if (value === null) {
@@ -1315,7 +1348,7 @@ function Chart(options) {
         if (chart.tableID) {
             var geoIDs = chart.geoIDs;
 
-            chart.tableURL =        '/data/table/?table='+chart.tableID+'&primary_geo_id='+chart.primaryGeoID+'&geo_ids='+geoIDs.join(',');
+            chart.tableURL = '/data/table/?table='+chart.tableID+'&primary_geo_id='+chart.primaryGeoID+'&geo_ids='+geoIDs.join(',');
 
             // when showing distribution and maps, try to show relevant geos right from
             // the start.

--- a/hurumap/templates/profile/profile_detail.html
+++ b/hurumap/templates/profile/profile_detail.html
@@ -873,10 +873,149 @@
       </div>
     </article>
   </div>
+{% endblock %}
+
+{% comment %} Override chart creation from wazimap/profile_detail.html {% endcomment %}
+{% block body_javascript_extra %}
 
   {% block profile_javascript_libs %}
-    <script src="{% static 'js/vendor/dom-to-image.min.js' %}"></script>
+  <script src="{% static 'js/vendor/dom-to-image.min.js' %}"></script>
 
-    {{ block.super }}
+  {{ block.super }}
   {% endblock %}
+<script type="text/javascript">
+
+// Create all the charts
+var Charts = {},
+    chartContainers = $('[id^=chart-]'),
+    defaultDataRelease = '{{ geography.census_release }}',
+    profileData = {{ profile_data_json }};
+var gracefulType = function(chartType) {
+    // convert certain chart types to more readable versions at narrow widths
+    if (browserWidth <= 640) {
+        if (chartType == 'column' || chartType == 'histogram') {
+            return 'bar'
+        } else if (chartType == 'grouped_column') {
+            return 'grouped_bar'
+        }
+    }
+    return chartType
+}
+var makeCharts = function() {
+    $.each(chartContainers, function(i, obj) {
+        $(obj).empty();
+        var chartID = $(this).prop('id'),
+            chartDataKey = chartID.replace('chart-','').replace('alt-',''),
+            chartDataID = chartDataKey.split('-'),
+            chartType = gracefulType(chartDataID[0]),
+            chartData = profileData[chartDataID[1]],
+            chartChartTitle = $(this).data('chart-title'),
+            chartChartShowYAxis = $(this).data('chart-show-y-axis'),
+            chartInitialSort = $(this).data('initial-sort'),
+            chartStatType = $(this).data('stat-type'),
+            chartDecimalPlaces = $(this).data('decimal-places'),
+            chartQualifier = $(this).data('qualifier') || null,
+            thisSource = $(this).data('source') || null,
+            geographyData = profileData['geography'],
+            comparisonLevels = {{ WAZIMAP.comparative_levels|safe }};
+        // allow arbitrary nesting in API data structure
+        var drilldown = chartDataID.length - 1;
+        if (drilldown >= 2) {
+            for (var n = 2; n <= drilldown; n++) {
+                chartData = chartData[chartDataID[n]]
+            }
+        }
+
+        // Display the source specified in data-source, else display the metadata source
+        var chartSource = thisSource ? thisSource : chartData['metadata']['source'];
+
+        // determine whether data point is from anything other
+        // than the primary ACS release for this page
+        for (var key in chartData) if (chartData.hasOwnProperty(key)) break;
+        var thisRelease = chartData[key]['acs_release'],
+            noteRelease = (thisRelease != defaultDataRelease) ? thisRelease + ' data' : null;
+
+        /*chartQualifier = (chartQualifier && noteRelease) ? Array(chartQualifier, noteRelease)
+            .filter(function(n) { return n }).join('; ') : null;*/
+
+        var chartstuff = {
+            chartContainer: chartID,
+            chartDataKey: chartDataKey,
+            chartType: chartType,
+            chartHeight: 160,
+            chartData: chartData,
+            chartQualifier: chartQualifier,
+            chartSource: chartSource,
+            chartChartTitle: chartChartTitle,
+            chartInitialSort: chartInitialSort,
+            chartStatType: chartStatType,
+            chartDecimalPlaces: chartDecimalPlaces,
+            geographyData: geographyData,
+            comparisonLevels: comparisonLevels
+        }
+        try {
+            Charts[i] = Chart(chartstuff);
+        } catch(e) {
+            console.log("Error making chart " + chartID)
+            console.log(e)
+            console.log(chartstuff);
+        }
+    });
+}
+var maps = new ProfileMaps();
+maps.drawMapsForProfile(profileData.geography);
+makeCharts();
+// listen for resize, redraw charts to new dimensions
+var lazyRedrawCharts = _.debounce(function() {
+    window.browserWidth = document.documentElement.clientWidth;
+    window.browserHeight = document.documentElement.clientHeight;
+    makeCharts();
+}, 50);
+$(window).resize(lazyRedrawCharts);
+// for touch devices, still allow context toggle
+$('.stat-row').on('click', '.stat', function() {
+    $(this).find('.context').toggle();
+});
+var parentLinkContainer = null;
+if (!!parentLinkContainer) {
+    // set up the listener for trigger to reveal hidden groups
+    $('#header-box').on('click', '.link-reveal', function() {
+        $(this).hide().next('.hidden').show();
+        return false;
+    });
+    // hit the /parents API endpoint
+    $.getJSON(parentGeoAPI)
+        .done(function(results) {
+            // filter out 'this' from the parents
+            var parents = _.reject(results['parents'], function(p) {
+                return p.relation === 'this';
+            });
+            // list of unique parent sumlev types, maintaining order
+            var parentRelations = _.uniq(_.pluck(parents, 'sumlevel'));
+            // collect parents into individual sumlev groups
+            var parentGroups = _.groupBy(parents, function(d) {
+                return d.sumlevel;
+            });
+            // for each parent sumlev type ...
+            var parentLinkSets = _.map(parentRelations, function(r) {
+                // ... compile a set of links to individual profile pages
+                var parentLinkSet = _.map(parentGroups[r], function(v, k) {
+                    return '<a href="/profiles/' + v.geoid + '-' + slugify(v.display_name) + '/">' + v.display_name + '</a>';
+                });
+                var numParents = parentLinkSet.length;
+                // if more than one of a sumlev type, group behind reveal link
+                if (numParents > 1) {
+                    return '<a href="#" class="link-reveal">'+numParents+' '+ sumlevMap[r]['plural'] +'</a><span class="hidden">'+parentLinkSet.join(', ')+'</span>';
+                } else {
+                    // just one of this sumlev type, so add it to list
+                    return parentLinkSet;
+                }
+            })
+            // push the whole thing into the header box ... thingy
+            parentLinkContainer.html(parentLinksPrefix + parentLinkSets.join(', '));
+            $('body').trigger('glossaryUpdate', parentLinkContainer);
+        });
+}
+
+</script>
 {% endblock %}


### PR DESCRIPTION
## Description

In order for a chart/viz to be taken serious, it must have the source of the data attributed.

This PR add ability to define source either as a link via `data-source` attribute on chart div (html) or as a `source` object in the `metadata` section of chart data (python). The second method also offer ability to separate the link and display title

```html

<div id='' ...... data-source='https://link'></div>

```

OR

```python

data['metadata']['source'] = {
    'title': 'Source Title',
    'link': 'https://link',
}

```

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Screenshots
![untitled](https://user-images.githubusercontent.com/1779590/45493081-a0681600-b776-11e8-957f-efab7558c2bc.png)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation