### PR TITLE
Add request context processor

### DIFF
--- a/hurumap/settings.py
+++ b/hurumap/settings.py
@@ -29,6 +29,7 @@ TEMPLATES = [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.i18n',
                 'django.template.context_processors.media',
+                'django.template.context_processors.request',
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',


### PR DESCRIPTION
## Description

`django.template.context_processors.request` was missing causing `KeyError` in templates that expects `request` key in `context` object.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation