### PR TITLE
Move js block outside profile_detail block

### DIFF
--- a/hurumap/templates/profile/profile_detail.html
+++ b/hurumap/templates/profile/profile_detail.html
@@ -44,7 +44,9 @@
   <div class="column-full">
     <p class="caption"><strong>Census data:</strong> 2009</p>
   </div>
-{% endblock %} {% block profile_detail %}
+{% endblock %}
+
+{% block profile_detail %}
 
 
   <article id="demographics"
@@ -873,10 +875,10 @@
       </div>
     </article>
   </div>
+{% endblock %}
 
-  {% block profile_javascript_libs %}
-    <script src="{% static 'js/vendor/dom-to-image.min.js' %}"></script>
+{% block profile_javascript_libs %}
+<script src="{% static 'js/vendor/dom-to-image.min.js' %}"></script>
 
-    {{ block.super }}
-  {% endblock %}
+{{ block.super }}
 {% endblock %}


### PR DESCRIPTION
## Description

`{% block profile_javascript_libs %}` was mistakenly declared inside `{% block profile_detail %}` block causing double initialization of JavaScript libraries as well as some libraries not being included.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation