### PR TITLE
[Feature] Multiple Chart Qualifiers Support

### DIFF
--- a/hurumap/static/js/charts.js
+++ b/hurumap/static/js/charts.js
@@ -1177,14 +1177,21 @@ function Chart(options) {
     }
 
     chart.addChartQualifier = function(container) {
-        if (!!chart.chartQualifier) {
+        var appendChartQualifier = function appendChartQualifier(chartQualifier, container, chart) {
             container.append("span")
                 .classed("chart-qualifier", true)
-                .text("* " + chart.chartQualifier);
+                .text("* " + chartQualifier);
 
             chart.updateSettings({
                 height: parseInt(chart.settings.height) + 20
             });
+        }
+
+        if (!!chart.chartQualifier) {
+            var chartQualifier = chart.chartQualifier.trim().split('\n');
+            for (i = 0; i < chartQualifier.length; i++) {
+                appendChartQualifier(chartQualifier[i], container, chart);
+            }
         }
     }
 

--- a/hurumap/templates/profile/profile_detail.html
+++ b/hurumap/templates/profile/profile_detail.html
@@ -757,15 +757,6 @@
     </div>
   </article>
 
-  <style>
-    .label {
-      word-break: break-word;
-    }
-
-    #chart-histogram-crimereport-crimes_dist .action-links {
-      margin-top: 40px;
-    }
-  </style>
   <article id="crime_report"
            class="clearfix {% if 'crime_report' not in selected_sections %}hide{% endif %}">
     <header class="section-contents">
@@ -790,11 +781,7 @@
       </section>
     </div>
   </article>
-  <style>
-    .label {
-      word-break: break-word;
-    }
-  </style>
+
   <div id="agriculture">
     <article id="crop_production" class="clearfix">
       <header class="section-contents">
@@ -875,7 +862,17 @@
       </div>
     </article>
   </div>
-{% endblock %}
+
+  <style>
+    .label {
+      word-break: break-word;
+    }
+
+    #chart-histogram-crimereport-crimes_dist .action-links {
+      margin-top: 40px;
+    }
+  </style>
++{% endblock profile_detail %}
 
 {% comment %} Override chart creation from wazimap/profile_detail.html {% endcomment %}
 {% block body_javascript_extra %}

--- a/hurumap/templates/profile/profile_detail.html
+++ b/hurumap/templates/profile/profile_detail.html
@@ -915,7 +915,7 @@ var makeCharts = function() {
             chartInitialSort = $(this).data('initial-sort'),
             chartStatType = $(this).data('stat-type'),
             chartDecimalPlaces = $(this).data('decimal-places'),
-            chartQualifier = $(this).data('qualifier') || null,
+            thisQualifier = $(this).data('qualifier') || null,
             thisSourceLink = $(this).data('source-link') || null,
             thisSourceTitle = $(this).data('source-title') || null,
             geographyData = profileData['geography'],
@@ -928,11 +928,15 @@ var makeCharts = function() {
             }
         }
 
+        // Display the source specified in data-qualifier attribute,
+        // else display the metadata qualifier
+        var chartQualifier = thisQualifier || chartData['metadata']['qualifier'] || null;
+
         // Display the source specified in data-source-link (and data-source-title),
         // else display the metadata source
-        var chartSource = chartData['metadata']['source'] || {};
-        var chartSourceLink = thisSourceLink || chartSource.link;
-        var chartSourceTitle = thisSourceTitle || chartSource.title;
+        var metadataSource = chartData['metadata']['source'] || {};
+        var chartSourceLink = thisSourceLink || metadataSource.link;
+        var chartSourceTitle = thisSourceTitle || metadataSource.title;
 
         // determine whether data point is from anything other
         // than the primary ACS release for this page


### PR DESCRIPTION
## Description

Currently HURUmap (and wazimap) only supports a single qualifier. This PR adds ability to have more than one qualifier. Due to html limitation of single `data-qualifier` attribute, the value of this attribute would need to be delimiter-ed to support multiple values. `\n` is used as delimiter.

```html

... data-qualifier="GF: Global Fund\nADF: African Development Fund" data-...

```

By adding multiple qualifiers support, one can use qualifiers to add legend to those charts, like histogram, that do not have a legend by default. This means shorter names can be used on the charts themselves leading to clean and easy to read charts.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)


## Screenshots

### Before
![screenshot from 2018-09-25 13-33-13](https://user-images.githubusercontent.com/1779590/46011873-ef477100-c0cf-11e8-9b61-9958480a87be.png)

### After
![screenshot from 2018-09-25 13-32-43](https://user-images.githubusercontent.com/1779590/46011895-fc646000-c0cf-11e8-8776-2db0318696b4.png)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation