### PR TITLE
Ensure source link opens in a `_blank` target

### DIFF
--- a/hurumap/static/js/charts.js
+++ b/hurumap/static/js/charts.js
@@ -1203,6 +1203,8 @@ function Chart(options) {
                     .text("Source: ")
                     .append("a")
                         .attr("href", chart.chartSourceLink)
+                        .attr("target", "_blank")
+                        .attr("rel", "noopener")
                         .text(chart.chartSourceTitle);
 
             chart.updateSettings({


### PR DESCRIPTION
## Description

HURUmap viz source links should open in a `_blank` target so that the site visitor does not leave the site they're currently on.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Screenshots
![peek 2018-09-28 16-01](https://user-images.githubusercontent.com/1779590/46210304-0341db80-c339-11e8-93a5-e3f6213436c3.gif)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation