### PR TITLE
[Bug] Navbar blog link point to CfA medium

### DIFF
--- a/hurumap/settings.py
+++ b/hurumap/settings.py
@@ -67,6 +67,7 @@ HURUMAP['title_tagline'] = 'Making Census Data Easy to Use'
 HURUMAP['facebook'] = 'CodeForAfrica'
 HURUMAP['twitter'] = '@Code4Africa'
 HURUMAP['email'] = 'hello@hurumap.org'
+HURUMAP['blog_url'] = 'https://medium.com/code-for-africa'
 
 HURUMAP['github_url'] = 'https://github.com/CodeForAfrica/HURUmap'
 HURUMAP['openafrica_url'] = 'https://open.africa/'

--- a/hurumap/templates/_base.html
+++ b/hurumap/templates/_base.html
@@ -52,7 +52,8 @@
         <ul id="site-menu">
           {% block header_menu %}
             <li><a href="/about">About</a></li>
-            <li><a href="/blog">Blog</a></li>
+            <li><a href="{{ HURUMAP.blog_url }}" target="_blank"
+              rel="noopener noreferrer">Blog</a></li>
             <li><a href="/#showcase">Showcase</a></li>
             <li><a href="https://facebook.com/HacksHackersAfrica"
                    target="_blank" rel="noopener">Community</a></li>


### PR DESCRIPTION
## Description
blog link in the navbar pointing to CfA's Medium publicaiton

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
![screenshot from 2018-11-09 12-07-30](https://user-images.githubusercontent.com/7962097/48253491-6e8ecb00-e418-11e8-8f1b-bf7ab311f545.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation