### PR TITLE
[Fix] Replace sourceAFRICA with openAFRICA on footer

### DIFF
--- a/hurumap/templates/_footer.html
+++ b/hurumap/templates/_footer.html
@@ -19,7 +19,7 @@
             <a href="https://taxclock.codeforkenya.org/" target="_blank" rel="noopener">Tax Clock</a>
         </li>
         <li>
-            <a href="https://sourceafrica.net/" target="_blank" rel="noopener">sourceAFRICA</a>
+            <a href="https://openafrica.net/" target="_blank" rel="noopener">openAFRICA</a>
         </li>
     </ul>
     <br/>


### PR DESCRIPTION
## Description
sourceAFRICA is a connectedAFRICA project so we should instead we point people to openAFRICA.net in the footer.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots
![screenshot from 2018-11-09 12-22-49](https://user-images.githubusercontent.com/7962097/48254403-05f51d80-e41b-11e8-9217-465fd676ef03.png)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation