### PR TITLE
Add missing show y axis to Chart options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ FROM hurumap as hurumap-kenya
 
 WORKDIR $APP_SRVHOME
 RUN mkdir hurumap_apps \
-    && wget -qO- https://github.com/CodeForAfrica/HURUmap-apps/archive/feature/python3.tar.gz | tar -xz --strip=1 -C hurumap_apps
+    && wget -qO- https://github.com/CodeForAfrica/HURUmap-apps/archive/master.tar.gz | tar -xz --strip=1 -C hurumap_apps
 
 WORKDIR $APP_SRVHOME/hurumap_apps
 

--- a/hurumap/settings.py
+++ b/hurumap/settings.py
@@ -302,6 +302,7 @@ HURUMAP['theme'] = {
                 "#8ecc23", "#fccd06", "#dbba97", "#aaaaaa"
             ],
         },
+        'show_y_axis': False,
         'color_scale': 'Set2S',
         'chart_height': 160
     }

--- a/hurumap/static/js/charts.js
+++ b/hurumap/static/js/charts.js
@@ -38,9 +38,9 @@ function Chart(options) {
     chart.decimalPlaces = parseInt(options.chartDecimalPlaces) || 0;
     chart.tableDecimalPlaces = parseInt(options.chartDecimalPlaces) || 1;
     chart.colorbrewer = options.colorbrewer;
-    chart.chartChartShowYAxis =
-      options.chartChartShowYAxis ||
-      (chart.chartStatType == "percentage" ? true : false);
+    chart.chartChartShowYAxis = options.chartChartShowYAxis ||
+        (window.HURUMAP_THEME && window.HURUMAP_THEME.charts.show_y_axis) ||
+	(chart.chartStatType === "percentage" ? true : false);
     chart.chartHeight =
       options.chartHeight ||
       (chart.parentHeight < 180 ? 180 : chart.parentHeight);

--- a/hurumap/templates/profile/profile_detail.html
+++ b/hurumap/templates/profile/profile_detail.html
@@ -984,7 +984,9 @@ var makeCharts = function() {
             comparisonLevels: comparisonLevels,
             colorbrewer: colorbrewer,
             chartColorScale: '{{ HURUMAP.theme.charts.color_scale }}',
-            chartChartShowYAxis: chartChartShowYAxis
+	    
+	    // Y-Axis can be enabled for the whole site or per chart
+            chartChartShowYAxis: ('{{ HURUMAP.theme.charts.show_y_axis }}' || chartChartShowYAxis)
 
         }
         try {

--- a/hurumap/templates/profile/profile_detail.html
+++ b/hurumap/templates/profile/profile_detail.html
@@ -983,7 +983,8 @@ var makeCharts = function() {
             geographyData: geographyData,
             comparisonLevels: comparisonLevels,
             colorbrewer: colorbrewer,
-            chartColorScale: '{{ HURUMAP.theme.charts.color_scale }}'
+            chartColorScale: '{{ HURUMAP.theme.charts.color_scale }}',
+            chartChartShowYAxis: chartChartShowYAxis
 
         }
         try {

--- a/hurumap/templates/profile/profile_detail.html
+++ b/hurumap/templates/profile/profile_detail.html
@@ -986,8 +986,7 @@ var makeCharts = function() {
             chartColorScale: '{{ HURUMAP.theme.charts.color_scale }}',
 	    
 	    // Y-Axis can be enabled for the whole site or per chart
-            chartChartShowYAxis: ('{{ HURUMAP.theme.charts.show_y_axis }}' || chartChartShowYAxis)
-
+            chartChartShowYAxis: ({{ HURUMAP.theme.charts.show_y_axis|yesno:"true,false" }} || chartChartShowYAxis)
         }
         try {
             Charts[i] = Chart(chartstuff);

--- a/hurumap/templates/settings_js.html
+++ b/hurumap/templates/settings_js.html
@@ -2,10 +2,11 @@
 {% load jsonify %}
 
 {% block settings_javascript %}
-{{block.super}}
+  {{ block.super }}
 
-var SITE_TAGLINE = '{{ WAZIMAP.title_tagline }}';
-var SITE_DESCRIPTION = '{{ WAZIMAP.description }}';
-var MAPIT = {{ HURUMAP.mapit|jsonify|safe }};
-var TILE_LAYER = {{ HURUMAP.tile_layer|jsonify|safe }};
+  var SITE_TAGLINE = '{{ WAZIMAP.title_tagline }}';
+  var SITE_DESCRIPTION = '{{ WAZIMAP.description }}';
+  var MAPIT = {{ HURUMAP.mapit|jsonify|safe }};
+  var TILE_LAYER = {{ HURUMAP.tile_layer|jsonify|safe }};
+  var HURUMAP_THEME = {{ HURUMAP.theme|jsonify|safe }};
 {% endblock settings_javascript %}


### PR DESCRIPTION
## Description
The option `show y axis` for charts is not included in the option object sent to Chart function. It is true for charts with percentage stat type only from the line (i.e `chart.chartChartShowYAxis =
      options.chartChartShowYAxis ||
      (chart.chartStatType == "percentage" ? true : false);` in `js/chart.js`. We want to be able to show y axis on other stat type too.

This PR adds `chartShowYAxis` to the options object

Fixes # (issue)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation